### PR TITLE
Fix the missing front matter on sprint3-mid report

### DIFF
--- a/content/en/pim/project-reports/sprint3-mid/index.md
+++ b/content/en/pim/project-reports/sprint3-mid/index.md
@@ -1,5 +1,8 @@
-Project report
-==============
+---
+title: Sprint 3  (mid sprint)
+date: 2024-06-12
+description: Sprint report for DHSC PIM Sprint 3  (mid sprint)
+---
 
 ![Dragon fruit](dragonFruit.jpg)
 


### PR DESCRIPTION
The front matter was accidently missed off the sprint3-mid report for PIM.  This caused the report to fail to show up in the projects site. This adds the frontmatter to the report.